### PR TITLE
Reference Error when module is not defined

### DIFF
--- a/human-view.js
+++ b/human-view.js
@@ -272,7 +272,7 @@
   });
 
 
-  if (!_.isUndefined(module) && !_.isUndefined(module.exports)) {
+  if (typeof module !== "undefined" && module !== null && !_.isUndefined(module.exports)) {
     module.exports = HumanView;
   } else {
     window.HumanView = HumanView;


### PR DESCRIPTION
It's not possible to pass a variable that hasn't been defined. This failed when running in standard browser environment.
