### PR TITLE
IE10 fix: when reRender calls addView via each, the view is rendered everytime

### DIFF
--- a/human-view.js
+++ b/human-view.js
@@ -253,8 +253,8 @@
             views.push(view);
             view.parent = self;
             view.renderedByParentView = true;
-            view.render({containerEl: container});
           }
+          view.render({containerEl: container});
           // give the option for the view to choose where it's inserted if you so choose
           if (!view.insertSelf) containerEl[options.reverse ? 'prepend' : 'append'](view.el);
           view.delegateEvents();


### PR DESCRIPTION
For some reason IE10 loses view.el.innerHTML when reRender() is run and calls addView() via each().

Newly added views are rendered correctly, but existing views all have an empty view.el.

With this change, each view calls render() whether or not it previously existed. This prevents IE10 from wiping the entire collection when create() is called on a child collection of a model.

Not sure if this is related to human-view and human-model being tied to Backbone 1.0.0 when Backbone 1.1.2 is available... I tried upgrading Backbone, but that broke everything. :-/
